### PR TITLE
Update action.yml use node20 instead of node16

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -44,6 +44,6 @@ outputs:
   output:
     description: The captured output of both stdout and stderr from the Ansible Playbook run
 runs:
-  using: node16
+  using: node20
   main: main.js
   post: post.js


### PR DESCRIPTION
To avoid this notification:

> The following actions use a deprecated Node.js version and will be forced to run on node20: aimerib/ansible-playwright@v2.7.7. For more info: https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/